### PR TITLE
Add macOS wrapper with Swift package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Node
+node_modules/
+/dist/
+LifeCalculatorV2/client/dist/
+
+# Swift Package Build artifacts
+.build/
+
+# macOS
+*.xcworkspace
+*.xcodeproj
+*.swiftpm
+DerivedData/
+
+# Others
+.DS_Store

--- a/MacOSApp/.gitignore
+++ b/MacOSApp/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/MacOSApp/Package.swift
+++ b/MacOSApp/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "MacOSApp",
+    platforms: [
+        .macOS(.v13)
+    ],
+    targets: [
+        .executableTarget(
+            name: "MacOSApp",
+            resources: [
+                .copy("dist")
+            ]
+        )
+    ]
+)

--- a/MacOSApp/README.md
+++ b/MacOSApp/README.md
@@ -1,0 +1,9 @@
+# MacOS Wrapper
+
+This Swift package provides a minimal macOS application for the Life Calculator project.
+
+1. Build the web client in `../LifeCalculatorV2` using `npm run build`.
+2. Copy the generated files from `LifeCalculatorV2/client/dist` into this package's `dist` directory.
+3. Open `Package.swift` in Xcode and run the app.
+
+The app loads the bundled files using `WKWebView`.

--- a/MacOSApp/Sources/MacOSApp/dist/README.txt
+++ b/MacOSApp/Sources/MacOSApp/dist/README.txt
@@ -1,0 +1,1 @@
+Place built web files here (from LifeCalculatorV2/client/dist)

--- a/MacOSApp/Sources/MacOSApp/main.swift
+++ b/MacOSApp/Sources/MacOSApp/main.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import WebKit
+
+@main
+struct LifeCalculatorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            WebView()
+                .frame(minWidth: 800, minHeight: 600)
+        }
+    }
+}
+
+struct WebView: NSViewRepresentable {
+    func makeNSView(context: Context) -> WKWebView {
+        let view = WKWebView()
+        if let indexURL = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "dist") {
+            view.loadFileURL(indexURL, allowingReadAccessTo: indexURL.deletingLastPathComponent())
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: WKWebView, context: Context) {}
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# lifecalculatorapp
+# Life Calculator
+
+This repository contains the source code for the **Life Calculator** application. The project is split into two main parts:
+
+- **LifeCalculatorV2/** – the web client and server written with React, Express and TypeScript.
+- **MacOSApp/** – a Swift package containing a minimal macOS wrapper application. This wrapper loads the built web client using `WKWebView` so the project can be distributed as a native macOS app.
+
+## Running the Web Version
+
+1. Install dependencies:
+   ```bash
+   cd LifeCalculatorV2
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The server runs on port `5000`.
+3. Build for production:
+   ```bash
+   npm run build
+   ```
+   The client will be compiled to `client/dist`.
+
+## Building the macOS App
+
+The `MacOSApp` directory is a Swift package that can be opened directly in Xcode. It contains a simple SwiftUI application that loads the `client/dist` files using `WKWebView`.
+
+Steps:
+
+1. Ensure the web client is built (`npm run build` as above).
+2. Open `MacOSApp/Package.swift` in Xcode.
+3. Add the contents of `LifeCalculatorV2/client/dist` to the `Resources` folder of the Xcode project (or adjust the paths in `ContentView.swift`).
+4. Build and run the app from Xcode.
+
+This setup allows the web application to be bundled and distributed as a native macOS application.


### PR DESCRIPTION
## Summary
- add a gitignore for node, Swift Package and macOS build files
- create `MacOSApp` Swift package to wrap the web client
- document build steps for the web and macOS versions
- refine ignore rules and move Swift sources under correct target directory

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684fc6a2f1488321bd1c14dacc4de68f